### PR TITLE
Replace dark mode li with button

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,9 +22,7 @@
             <li>
                 <a href="mailto:antsevestre@outlook.fr">Contact</a>
             </li>
-            <li id="dark_light_mode" onclick="changeDarkMode()">
-                Dark mode
-            </li>
+            <button id="dark_light_mode" type="button" onclick="changeDarkMode()">Dark mode</button>
         </ul>
     </nav>
 

--- a/style.css
+++ b/style.css
@@ -36,6 +36,23 @@ nav ul li{
     position: relative;
 }
 
+nav button#dark_light_mode{
+    margin-left: 40px;
+    font-size: 15px;
+    cursor: pointer;
+    position: relative;
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    color: inherit;
+}
+
+nav button#dark_light_mode:focus{
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+}
+
 nav ul li a{
     text-decoration: none;
     color: inherit;


### PR DESCRIPTION
## Summary
- replace list item with a real button for the dark mode toggle
- style the button to match navigation items and show a focus outline

## Testing
- `npm test` *(fails: package.json missing)*
- `python3 -m pytest`
- `node -e "const {JSDOM}=require('jsdom');"` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862ac1f729883269676051e03eb634f