### PR TITLE
Persist theme preference

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -1,17 +1,26 @@
 let darkMode = false;
 
-function changeDarkMode(){
+function applyTheme(){
     if(darkMode){
-        // light mode
-        darkMode = false;
-        document.documentElement.style.setProperty("--text-color", "#202124");
-        document.documentElement.style.setProperty("--background-color", "#efe7e5");
-        document.getElementById("dark_light_mode").innerHTML = "Dark mode";  
-    }else{
         // dark mode
-        darkMode = true;
         document.documentElement.style.setProperty("--text-color", "white");
         document.documentElement.style.setProperty("--background-color", "#202124");
         document.getElementById("dark_light_mode").innerHTML = "Light mode";
+    }else{
+        // light mode
+        document.documentElement.style.setProperty("--text-color", "#202124");
+        document.documentElement.style.setProperty("--background-color", "#efe7e5");
+        document.getElementById("dark_light_mode").innerHTML = "Dark mode";
     }
 }
+
+function changeDarkMode(){
+    darkMode = !darkMode;
+    localStorage.setItem("darkMode", darkMode ? "on" : "off");
+    applyTheme();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    darkMode = localStorage.getItem("darkMode") === "on";
+    applyTheme();
+});


### PR DESCRIPTION
## Summary
- save dark mode preference to `localStorage`
- apply saved theme on page load
- adjust button text based on stored preference

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862b0d3ba6083268fdf85c30f856c47